### PR TITLE
IE11系のバグ対応

### DIFF
--- a/lib/browser/tag/parse.js
+++ b/lib/browser/tag/parse.js
@@ -3,6 +3,7 @@
 function parseNamedElements(root, tag, childTags, forceParsingNamed) {
 
   walk(root, function(dom) {
+    dom.innerHTML = dom.innerHTML //IE系のバグがこれで治った。DOM Treeにおかしな改行が入ることがあり、DOMがぶった切られる対応。
     if (dom.nodeType == 1) {
       dom.isLoop = dom.isLoop ||
                   (dom.parentNode && dom.parentNode.isLoop || getAttr(dom, 'each'))

--- a/lib/browser/tag/parse.js
+++ b/lib/browser/tag/parse.js
@@ -3,7 +3,7 @@
 function parseNamedElements(root, tag, childTags, forceParsingNamed) {
 
   walk(root, function(dom) {
-    dom.innerHTML = dom.innerHTML //IE系のバグがこれで治った。DOM Treeにおかしな改行が入ることがあり、DOMがぶった切られる対応。
+    if (IE_VERSION === 11) dom.innerHTML = dom.innerHTML //IE系のバグがこれで治った。DOM Treeにおかしな改行が入ることがあり、DOMがぶった切られる対応。
     if (dom.nodeType == 1) {
       dom.isLoop = dom.isLoop ||
                   (dom.parentNode && dom.parentNode.isLoop || getAttr(dom, 'each'))


### PR DESCRIPTION
ほんと謎ですがこれで治りました。。

IE11で、nodeValueがおかしなところで改行されDOM構造ごとぶった切られてしまう問題に対応。

この辺りの動きに近いと思われますが・・。
http://stackoverflow.com/questions/33961311/ie11-innerhtml-strange-behaviour
